### PR TITLE
Fix a crash when a section has no items

### DIFF
--- a/NHAlignmentFlowLayout/NHAlignmentFlowLayout.m
+++ b/NHAlignmentFlowLayout/NHAlignmentFlowLayout.m
@@ -15,7 +15,9 @@
     for (UICollectionViewLayoutAttributes* attributes in array) {
         if (nil == attributes.representedElementKind) {
             NSIndexPath* indexPath = attributes.indexPath;
-            attributes.frame = [self layoutAttributesForItemAtIndexPath:indexPath].frame;
+            if ([self.collectionView numberOfItemsInSection:indexPath.section] > 0) {
+                attributes.frame = [self layoutAttributesForItemAtIndexPath:indexPath].frame;
+            }
         }
     }
     return array;


### PR DESCRIPTION
If a section returns "0" has the numberOfItems, UICollectionView will crash with an assert because it was asked for the [layoutAttributesForItemAtIndexPath:] for an invalid indexPath.
